### PR TITLE
Python 3.3 and 2.7 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.Python
 /.idea/
+/.tox/
 /bin/
 /build/
 /dist/
@@ -7,3 +8,4 @@
 /lib/
 /segtok.egg-info/
 __pycache__
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python: 2.7
+env:
+- TOXENV=py33
+- TOXENV=py34
+install:
+- pip install tox
+script:
+- tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python: 2.7
 env:
+- TOXENV=py27
+- TOXENV=py27-locale
 - TOXENV=py33
 - TOXENV=py34
 install:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,15 @@
 ======
 segtok
 ======
+
+.. image:: https://img.shields.io/pypi/v/segtok.svg
+    :target: https://pypi.python.org/pypi/segtok
+
+.. image:: https://img.shields.io/pypi/l/segtok.svg
+
+.. image:: https://img.shields.io/travis/kmike/segtok.svg?branch=py2
+    :target: https://travis-ci.org/kmike/segtok
+
 -------------------------------------------
 Sentence segmentation and word tokenization
 -------------------------------------------

--- a/segtok/segmenter.py
+++ b/segtok/segmenter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 A pattern-based sentence segmentation strategy; Known limitations:
 
@@ -24,6 +24,8 @@ Sentence splits will always be enforced at [consecutive] line separators.
 Important: Windows text files use ``\\r\\n`` as linebreaks and Mac files use ``\\r``;
 Convert the text to Unix linebreaks if the case.
 """
+from __future__ import absolute_import, unicode_literals
+import codecs
 from regex import compile, DOTALL, UNICODE, VERBOSE
 
 
@@ -272,14 +274,14 @@ def _abbreviation_joiner(spans):
         yield makeSentence(segment, total)
 
 
-def _is_open(span: str, brackets='()'):
+def _is_open(span_str, brackets='()'):
     """Check if the span ends with an unclosed `bracket`."""
-    offset = span.find(brackets[0])
+    offset = span_str.find(brackets[0])
     nesting = 0 if offset == -1 else 1
 
     while offset != -1:
-        opener = span.find(brackets[0], offset + 1)
-        closer = span.find(brackets[1], offset + 1)
+        opener = span_str.find(brackets[0], offset + 1)
+        closer = span_str.find(brackets[1], offset + 1)
 
         if opener == -1:
             if closer == -1:
@@ -303,14 +305,14 @@ def _is_open(span: str, brackets='()'):
     return nesting > 0
 
 
-def _is_not_opened(span: str, brackets='()'):
+def _is_not_opened(span_str, brackets='()'):
     """Check if the span starts with an unopened `bracket`."""
-    offset = span.rfind(brackets[1])
+    offset = span_str.rfind(brackets[1])
     nesting = 0 if offset == -1 else 1
 
     while offset != -1:
-        opener = span.rfind(brackets[0], 0, offset)
-        closer = span.rfind(brackets[1], 0, offset)
+        opener = span_str.rfind(brackets[0], 0, offset)
+        closer = span_str.rfind(brackets[1], 0, offset)
 
         if opener == -1:
             if closer == -1:
@@ -372,9 +374,12 @@ def main():
 
     if args.files:
         for txt_file_path in args.files:
-            segment(open(txt_file_path, 'rt', encoding='UTF-8').read())
+            with codecs.open(txt_file_path, 'rt', encoding='utf-8') as fp:
+                segment(fp.read())
     else:
         for line in stdin:
+            if isinstance(line, bytes):  # Python 2.x
+                line = line.decode('utf-8')
             segment(line)
 
 

--- a/segtok/segmenter_test.py
+++ b/segtok/segmenter_test.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from __future__ import absolute_import, division, unicode_literals
 from unittest import TestCase
 from segtok.segmenter import split_single, split_multi, MAY_CROSS_ONE_LINE, \
     split_newline, rewrite_line_separators, ABBREVIATIONS, NON_UNIX_LINEBREAK, \

--- a/segtok/tokenizer.py
+++ b/segtok/tokenizer.py
@@ -1,19 +1,24 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Regex-based word tokenizers.
 
 Note that small/full/half-width character variants are *not* covered.
 If a text were to contains such characters, normalize it first.
 """
-from regex import compile, UNICODE, VERBOSE
-
+from __future__ import absolute_import, unicode_literals
+import codecs
 try:
     from html import unescape
 except ImportError:
     # Python <= 3.3 doesn't have html.unescape
-    from html.parser import HTMLParser
-    _parser = HTMLParser()
-    unescape = _parser.unescape
+    try:
+        from html.parser import HTMLParser
+    except ImportError:
+        # Python 2.x
+        from HTMLParser import HTMLParser
+    unescape = HTMLParser().unescape
+
+from regex import compile, UNICODE, VERBOSE
 
 try:
     from segtok.segmenter import SENTENCE_TERMINALS, HYPHENS
@@ -354,10 +359,13 @@ def main():
 
     if args.files:
         for txt_file_path in args.files:
-            for line in open(txt_file_path, encoding='utf-8'):
-                _tokenize(line, tokenizer)
+            with codecs.open(txt_file_path, 'rt', encoding='utf-8') as fp:
+                for line in fp:
+                    _tokenize(line, tokenizer)
     else:
         for line in stdin:
+            if isinstance(line, bytes):  # Python 2.x
+                line = line.decode('utf-8')
             _tokenize(line, tokenizer)
 
 

--- a/segtok/tokenizer.py
+++ b/segtok/tokenizer.py
@@ -5,8 +5,15 @@ Regex-based word tokenizers.
 Note that small/full/half-width character variants are *not* covered.
 If a text were to contains such characters, normalize it first.
 """
-from html import unescape
 from regex import compile, UNICODE, VERBOSE
+
+try:
+    from html import unescape
+except ImportError:
+    # Python <= 3.3 doesn't have html.unescape
+    from html.parser import HTMLParser
+    _parser = HTMLParser()
+    unescape = _parser.unescape
 
 try:
     from segtok.segmenter import SENTENCE_TERMINALS, HYPHENS

--- a/segtok/tokenizer_test.py
+++ b/segtok/tokenizer_test.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from __future__ import absolute_import, division, unicode_literals
 from unittest import TestCase
 from segtok.tokenizer import space_tokenizer, symbol_tokenizer, word_tokenizer, web_tokenizer, IS_POSSESSIVE, \
     split_possessive_markers, IS_CONTRACTION, split_contractions

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Topic :: Software Development :: Libraries',
         'Topic :: Text Processing',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from setuptools import setup
 
 try:
@@ -28,6 +29,8 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,11 @@
 [tox]
-envlist = py33,py34
+envlist = py27,py33,py34,py27-locale
 
 [testenv]
 deps = pytest
 commands = py.test {posargs:segtok}
+
+[testenv:py27-locale]
+basepython = python2.7
+setenv =
+    LC_ALL=C

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py33,py34
+
+[testenv]
+deps = pytest
+commands = py.test {posargs:segtok}


### PR DESCRIPTION
Hi Florian,

I've added Python 2.7 and Python 3.3 support in this PR and created Travis CI config to check Python version compatibility on each commit / PR.

In Python 2.x command-line utility could breaks if console encoding is not utf-8 (i.e. systems with LC_ALL=C), but with utf-8 encoding it works. Python library should work fine in Python 2.x regardless of system settings.
