### PR TITLE
Broken sentence terminal splice at token boundary in some cases.

### DIFF
--- a/segtok/tokenizer.py
+++ b/segtok/tokenizer.py
@@ -254,7 +254,7 @@ def word_tokenizer(sentence):
             elif any(word.find(t) == 0 for t in SENTENCE_TERMINALS):
                 # ".stuff"
                 tokens[-idx] = word[0]
-                tokens.insert(len(tokens) - idx, word[:-1])
+                tokens.insert(len(tokens) - idx + 1, word[1:])
 
             break
 

--- a/segtok/tokenizer_test.py
+++ b/segtok/tokenizer_test.py
@@ -223,6 +223,16 @@ class TestWordTokenizer(TestCase):
         tokens = [u'1.2.3', u',', u'f.e.', u',', u'is', u'Mr.', u'.', u'Abbreviation', u'.']
         self.assertSequenceEqual(tokens, self.tokenizer(sentence))
 
+    def test_splice_sentence_terminal_start(self):
+        sentence = u"This is a ?sentence,"
+        tokens = [u'This', u'is', u'a', u'?', u'sentence', u',']
+        self.assertSequenceEqual(tokens, self.tokenizer(sentence))
+
+    def test_splice_sentence_terminal_end(self):
+        sentence = u"This is a sentence?,"
+        tokens = [u'This', u'is', u'a', u'sentence', u'?', u',']
+        self.assertSequenceEqual(tokens, self.tokenizer(sentence))
+
     def test_final_abbreviation(self):
         sentence = u"This is another abbrev..\n"
         tokens = [u'This', u'is', u'another', u'abbrev.', u'.']

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except IOError:
 
 setup(
     name='segtok',
-    version='1.5.6',
+    version='1.5.7',
     url='https://github.com/fnl/segtok',
     author='Florian Leitner',
     author_email='florian.leitner@gmail.com',


### PR DESCRIPTION
small bug in splicing sentence boundaries off of tokens leads to change in character output. proposed fix plus added test
```
>>>word_tokenizer('This is a test?,')
['This', 'is', 'a', 'test', '?', '?']
```