### PR TITLE
Remove license file from data_files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     description='sentence segmentation and word tokenization tools',
     keywords='sentence segmenter splitter split word tokenizer token',
     license='MIT',
-    data_files = [("", ["LICENSE.txt"])],
+    license_files=('LICENSE.txt',),
     packages=['segtok'],
     install_requires=['regex'],  # handles all Unicode categories in Regular Expressions
     long_description=long_description,


### PR DESCRIPTION
Having the license file in data_files causees the license file to get placed in the root folder of the environment (beside lib, bin, etc folder) which is not the place where it should be. It also disables us to codesign the Python application that we distribute as a macOS app.

In this PR I remove the license file from data_files since it is not required to have there. The license file gets placed in the package (tar.gz) anyway. I would be more than happy if you can merge this and make a new release of a package. 